### PR TITLE
Skip unchanged records filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "magento2-module",
     "require": {
         "php": "^7.3",
+        "ext-json": "*",
         "tightenco/collect": "^7.2",
         "trash-panda/progress-bar-log": "^1.1",
         "magento/framework": "^102",

--- a/src/Archiver/Csv/Entity/Archive.php
+++ b/src/Archiver/Csv/Entity/Archive.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\Import\Archiver\Csv\Entity;
+
+use Magento\Framework\Model\AbstractModel;
+
+class Archive extends AbstractModel
+{
+    public function _construct() // @codingStandardsIgnoreLine
+    {
+        $this->_init(ArchiveResource::class);
+    }
+
+    public function isFileDeleted() : bool
+    {
+        return (bool) $this->getData('deleted');
+    }
+
+    public function isFileArchived() : bool
+    {
+        return (bool) $this->getData('archived');
+    }
+
+    public function isFileAvailable() : bool
+    {
+        return !$this->isFileDeleted() && !$this->isFileArchived();
+    }
+}

--- a/src/Archiver/Csv/Entity/ArchiveResource.php
+++ b/src/Archiver/Csv/Entity/ArchiveResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\Import\Archiver\Csv\Entity;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class ArchiveResource extends AbstractDb
+{
+    /**
+     * @var ArchiveFactory
+     */
+    private $archiveFactory;
+
+    public function __construct(ArchiveFactory $archiveFactory, Context $context, $connectionName = null)
+    {
+        $this->archiveFactory = $archiveFactory;
+        parent::__construct($context, $connectionName);
+    }
+
+    protected function _construct() // @codingStandardsIgnoreLine
+    {
+        $this->_init('jh_import_archive_csv', 'id');
+    }
+
+    public function getBySourceId(string $sourceId) : Archive
+    {
+        $archive = $this->archiveFactory->create();
+
+        $this->load($archive, $sourceId, 'source_id');
+
+        return $archive;
+    }
+}

--- a/src/Entity/ImportHistory.php
+++ b/src/Entity/ImportHistory.php
@@ -22,9 +22,4 @@ class ImportHistory extends AbstractModel
     {
         return new \DateTime($this->getData('started'));
     }
-
-    public function getLastImportByName(string $importName): self
-    {
-        return $this->getResource()->getLastImportByName($this, $importName);
-    }
 }

--- a/src/Entity/ImportHistory.php
+++ b/src/Entity/ImportHistory.php
@@ -22,4 +22,9 @@ class ImportHistory extends AbstractModel
     {
         return new \DateTime($this->getData('started'));
     }
+
+    public function getLastImportByName(string $importName): self
+    {
+        return $this->getResource()->getLastImportByName($this, $importName);
+    }
 }

--- a/src/Entity/ImportHistoryResource.php
+++ b/src/Entity/ImportHistoryResource.php
@@ -3,6 +3,7 @@
 namespace Jh\Import\Entity;
 
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\Context;
 
 /**
  * @author Aydin Hassan <aydin@wearejh.com>
@@ -10,10 +11,41 @@ use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 class ImportHistoryResource extends AbstractDb
 {
     /**
+     * @var ImportHistoryFactory
+     */
+    private $importHistoryFactory;
+
+    public function __construct(ImportHistoryFactory $importHistoryFactory, Context $context, $connectionName = null)
+    {
+        $this->importHistoryFactory = $importHistoryFactory;
+        parent::__construct($context, $connectionName);
+    }
+
+    /**
      * Resource initialization
      */
     public function _construct() // @codingStandardsIgnoreLine
     {
         $this->_init('jh_import_history', 'id');
+    }
+
+    public function getLastImportByName(string $importName) : ImportHistory
+    {
+        $model = $this->importHistoryFactory->create();
+
+        $select = $this->getConnection()
+            ->select()
+            ->from($this->getMainTable())
+            ->where('import_name', $importName)
+            ->order('finished')
+            ->limitPage(1, 1);
+
+        $row = $this->getConnection()->fetchRow($select);
+
+        if ($row) {
+            $model->setData($row);
+        }
+
+        return $model;
     }
 }

--- a/src/Filter/SkipUnchangedRecordsFromLastImport.php
+++ b/src/Filter/SkipUnchangedRecordsFromLastImport.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\Import\Filter;
+
+use Jh\Import\Archiver\Csv\Entity\ArchiveResource;
+use Jh\Import\Config;
+use Jh\Import\Entity\ImportHistory;
+use Jh\Import\Entity\ImportHistoryResource;
+use Jh\Import\Import\Record;
+use Jh\Import\Entity\ImportHistoryFactory;
+use Jh\Import\Import\RequiresPreparation;
+use Jh\Import\Source\SourceConsumer;
+use Jh\Import\Source\SourceFactory;
+use Magento\Framework\DataObject;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+class SkipUnchangedRecordsFromLastImport implements RequiresPreparation
+{
+    /**
+     * @var Config
+     */
+    private $importConfig;
+
+    /**
+     * @var ImportHistoryResource
+     */
+    private $importHistoryResource;
+
+    /**
+     * @var ArchiveResource
+     */
+    private $csvArchiveResource;
+
+    /**
+     * @var DirectoryList
+     */
+    private $directoryList;
+
+    /**
+     * @var SourceFactory
+     */
+    private $sourceFactory;
+
+    /**
+     * @var SourceConsumer
+     */
+    private $sourceConsumer;
+
+    /**
+     * @var ImportHistory
+     */
+    private $previousImport;
+
+    /**
+     * @var Record[]
+     */
+    private $previousImportData = [];
+
+    public function __construct(
+        ImportHistoryResource $importHistoryResource,
+        ArchiveResource $csvArchiveResource,
+        DirectoryList $directoryList,
+        SourceFactory $sourceFactory,
+        SourceConsumer $sourceConsumer
+    ) {
+        $this->importHistoryResource = $importHistoryResource;
+        $this->csvArchiveResource = $csvArchiveResource;
+        $this->directoryList = $directoryList;
+        $this->sourceFactory = $sourceFactory;
+        $this->sourceConsumer = $sourceConsumer;
+    }
+
+    public function prepare(Config $config): void
+    {
+        $this->importConfig = $config;
+
+        $this->previousImport = $this->importHistoryResource->getLastImportByName(
+            $this->importConfig->getImportName()
+        );
+
+        if ($this->previousImport->getId() === null) {
+            //first import of this type
+            return;
+        }
+
+        $archive = $this->csvArchiveResource
+            ->getBySourceId($this->previousImport->getData('source_id'));
+
+        if (!$archive->isFileAvailable()) {
+            return;
+        }
+
+        $this->loadPreviousImport(
+            sprintf(
+                '%s/%s',
+                $this->directoryList->getPath(DirectoryList::VAR_DIR),
+                $archive['file_location']
+            )
+        );
+    }
+
+    private function loadPreviousImport(string $filePath) : void
+    {
+        //TODO: Bail out of file does not exist
+        //TODO: from manual deletion
+        $source = $this->sourceFactory
+            ->create(
+                $this->importConfig,
+                ['file' => $filePath]
+            );
+
+        $prevData = $this->sourceConsumer
+            ->toArray($source, $this->importConfig);
+
+        $this->previousImportData = collect($prevData)
+            ->keyBy(function (Record $record) {
+                return $this->hashRecord($record);
+            })
+            ->toArray();
+    }
+
+    public function __invoke(Record $record)
+    {
+        if (!$this->previousImport) {
+            //if we have no previous import then
+            //no records should be filtered
+            return true;
+        }
+
+        return !isset($this->previousImportData[$this->hashRecord($record)]);
+    }
+
+    private function hashRecord(Record $record): string
+    {
+        return md5(json_encode($record->asArray(), JSON_THROW_ON_ERROR));
+    }
+}

--- a/src/Filter/SkipUnchangedRecordsFromLastImport.php
+++ b/src/Filter/SkipUnchangedRecordsFromLastImport.php
@@ -112,6 +112,9 @@ class SkipUnchangedRecordsFromLastImport implements RequiresPreparation
                 ['file' => $filePath]
             );
 
+        //TODO: Do we even need the data in memory?
+        //TODO: We could probably read the file as an iterator (thus not loading at once)
+        //TODO: And then only keep the hash in memory
         $prevData = $this->sourceConsumer
             ->toArray($source, $this->importConfig);
 

--- a/src/Filter/SkipUnchangedRecordsFromLastImport.php
+++ b/src/Filter/SkipUnchangedRecordsFromLastImport.php
@@ -89,6 +89,7 @@ class SkipUnchangedRecordsFromLastImport implements RequiresPreparation
             ->getBySourceId($this->previousImport->getData('source_id'));
 
         if (!$archive->isFileAvailable()) {
+            //file has been deleted or archived (zipped)
             return;
         }
 

--- a/src/Source/SourceConsumer.php
+++ b/src/Source/SourceConsumer.php
@@ -18,8 +18,8 @@ class SourceConsumer
         $data = [];
 
         $source->traverse(
-            function (int $rowNumber, array $row) use ($config, &$data) {
-                $data[$row[$config->getIdField()]] = new Record($rowNumber, $row);
+            function (int $rowNumber, array $row) use (&$data) {
+                $data[] = new Record($rowNumber, $row);
             },
             function ($rowNumber) {
                 //noop - error reading/parsing row

--- a/test/Archiver/Csv/Entity/ArchiveTest.php
+++ b/test/Archiver/Csv/Entity/ArchiveTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\ImportTest\Archiver\Csv\Entity;
+
+use Jh\Import\Archiver\Csv\Entity\Archive;
+use Jh\UnitTestHelpers\ObjectHelper;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use PHPUnit\Framework\TestCase;
+
+class ArchiveTest extends TestCase
+{
+    use ObjectHelper;
+
+    public function testIsFileAvailableReturnsTrueIfNotDeletedOrArchived() : void
+    {
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        /** @var Archive $archive */
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData('deleted', false);
+        $archive->setData('archived', false);
+
+        self::assertTrue($archive->isFileAvailable());
+    }
+
+    public function testIsFileAvailableReturnsFalseIfFileIsArchived() : void
+    {
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        /** @var Archive $archive */
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData('deleted', false);
+        $archive->setData('archived', true);
+
+        self::assertFalse($archive->isFileAvailable());
+    }
+
+    public function testIsFileAvailableReturnsFalseIfFileIsDeleted() : void
+    {
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        /** @var Archive $archive */
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData('deleted', false);
+        $archive->setData('archived', true);
+
+        self::assertFalse($archive->isFileAvailable());
+    }
+
+    public function testIsFileAvailableReturnsFalseIfFileIsDeletedAndArchived() : void
+    {
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        /** @var Archive $archive */
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData('deleted', true);
+        $archive->setData('archived', true);
+
+        self::assertFalse($archive->isFileAvailable());
+    }
+}

--- a/test/Entity/ImportHistoryTest.php
+++ b/test/Entity/ImportHistoryTest.php
@@ -14,7 +14,7 @@ class ImportHistoryTest extends TestCase
 {
     use ObjectHelper;
 
-    public function testGetStartedAt()
+    public function testGetStartedAt() : void
     {
         $resource = $this->prophesize(AbstractDb::class);
         $resource->getIdFieldName()->willReturn('id');

--- a/test/Filter/SkipUnchangedRecordsFromLastImportTest.php
+++ b/test/Filter/SkipUnchangedRecordsFromLastImportTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jh\ImportTest\Filter;
+
+use Jh\Import\Archiver\Csv\Entity\Archive;
+use Jh\Import\Archiver\Csv\Entity\ArchiveResource;
+use Jh\Import\Config;
+use Jh\Import\Entity\ImportHistory;
+use Jh\Import\Entity\ImportHistoryResource;
+use Jh\Import\Filter\SkipUnchangedRecordsFromLastImport;
+use Jh\Import\Import\Record;
+use Jh\Import\Source\Iterator;
+use Jh\Import\Source\SourceConsumer;
+use Jh\Import\Source\SourceFactory;
+use Jh\UnitTestHelpers\ObjectHelper;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class SkipUnchangedRecordsFromLastImportTest extends TestCase
+{
+    use ObjectHelper;
+
+    /**
+     * @var string
+     */
+    private $tempRoot;
+
+    /**
+     * @var DirectoryList
+     */
+    private $directoryList;
+
+    public function setUp() : void
+    {
+        $this->tempRoot = sprintf('%s/%s', sys_get_temp_dir(), $this->getName());
+        @mkdir($this->tempRoot, 0777, true);
+
+        $this->directoryList = new DirectoryList($this->tempRoot);
+    }
+
+
+    public function testUnchangedRecordsAreSkipped() : void
+    {
+        $data = [
+            ['country' => 'Austria', 'code' => 'AT'],
+            ['country' => 'United Kingdom', 'code' => 'UK'],
+        ];
+
+        $config = new Config('my-import', ['source' => 'My/Source']);
+        $source = Iterator::fromCallable(function () use ($data) {
+            yield from $data;
+        });
+
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        $importHistory = $this->getObject(ImportHistory::class, ['resource' => $resource->reveal()]);
+        $importHistory->setData(['id' => 10, 'source_id' => 'AE53J6FFSTT33H']);
+
+        $importHistoryResource = $this->prophesize(ImportHistoryResource::class);
+        $importHistoryResource->getLastImportByName('my-import')->willReturn($importHistory);
+
+        $file = 'jh_import/archived/file-05062020123739.csv';
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData(['id' => 10, 'deleted' => false, 'archived' => false, 'file_location' => $file]);
+
+        $archiveResource = $this->prophesize(ArchiveResource::class);
+        $archiveResource->getBySourceId('AE53J6FFSTT33H')->willReturn($archive);
+
+        $om = $this->prophesize(ObjectManagerInterface::class);
+        $om->create('My/Source', ['file' => sprintf('%s/var/%s', $this->tempRoot, $file)])->willReturn($source);
+
+        $filter = new SkipUnchangedRecordsFromLastImport(
+            $importHistoryResource->reveal(),
+            $archiveResource->reveal(),
+            $this->directoryList,
+            new SourceFactory($om->reveal()),
+            new SourceConsumer(),
+        );
+
+        $filter->prepare($config);
+
+        self::assertFalse($filter->__invoke(new Record(0, ['country' => 'Austria', 'code' => 'AT'])));
+        self::assertFalse($filter->__invoke(new Record(0, ['country' => 'United Kingdom', 'code' => 'UK'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Turkey', 'code' => 'TR'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'France', 'code' => 'FR'])));
+    }
+
+    public function testAllRecordsAreProcessedIfNoDuplicates() : void
+    {
+        $config = new Config('my-import', ['source' => 'My/Source']);
+        $source = new Iterator(new \ArrayIterator([]));
+
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        $importHistory = $this->getObject(ImportHistory::class, ['resource' => $resource->reveal()]);
+        $importHistory->setData(['id' => 10, 'source_id' => 'AE53J6FFSTT33H']);
+
+        $importHistoryResource = $this->prophesize(ImportHistoryResource::class);
+        $importHistoryResource->getLastImportByName('my-import')->willReturn($importHistory);
+
+        $file = 'jh_import/archived/file-05062020123739.csv';
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData(['id' => 10, 'deleted' => false, 'archived' => false, 'file_location' => $file]);
+
+        $archiveResource = $this->prophesize(ArchiveResource::class);
+        $archiveResource->getBySourceId('AE53J6FFSTT33H')->willReturn($archive);
+
+        $om = $this->prophesize(ObjectManagerInterface::class);
+        $om->create('My/Source', ['file' => sprintf('%s/var/%s', $this->tempRoot, $file)])->willReturn($source);
+
+        $filter = new SkipUnchangedRecordsFromLastImport(
+            $importHistoryResource->reveal(),
+            $archiveResource->reveal(),
+            $this->directoryList,
+            new SourceFactory($om->reveal()),
+            new SourceConsumer(),
+        );
+
+        $filter->prepare($config);
+
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Austria', 'code' => 'AT'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'United Kingdom', 'code' => 'UK'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Turkey', 'code' => 'TR'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'France', 'code' => 'FR'])));
+    }
+
+    public function testAllRecordsAreProcessedIfNoPreviousImport() : void
+    {
+        $config = new Config('my-import', ['source' => 'My/Source']);
+
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        $importHistory = $this->getObject(ImportHistory::class, ['resource' => $resource->reveal()]);
+
+        $importHistoryResource = $this->prophesize(ImportHistoryResource::class);
+        $importHistoryResource->getLastImportByName('my-import')->willReturn($importHistory);
+
+        $filter = new SkipUnchangedRecordsFromLastImport(
+            $importHistoryResource->reveal(),
+            $this->prophesize(ArchiveResource::class)->reveal(),
+            $this->directoryList,
+            new SourceFactory($this->prophesize(ObjectManagerInterface::class)->reveal()),
+            new SourceConsumer(),
+        );
+
+        $filter->prepare($config);
+
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Austria', 'code' => 'AT'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'United Kingdom', 'code' => 'UK'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Turkey', 'code' => 'TR'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'France', 'code' => 'FR'])));
+    }
+
+
+    public function testAllRecordsAreProcessedIfNoPreviousFileExists() : void
+    {
+        $config = new Config('my-import', ['source' => 'My/Source']);
+
+        $resource = $this->prophesize(AbstractDb::class);
+        $resource->getIdFieldName()->willReturn('id');
+
+        $importHistory = $this->getObject(ImportHistory::class, ['resource' => $resource->reveal()]);
+        $importHistory->setData(['id' => 10, 'source_id' => 'AE53J6FFSTT33H']);
+
+        $importHistoryResource = $this->prophesize(ImportHistoryResource::class);
+        $importHistoryResource->getLastImportByName('my-import')->willReturn($importHistory);
+
+        $file = 'jh_import/archived/file-05062020123739.csv';
+        $archive = $this->getObject(Archive::class, ['resource' => $resource->reveal()]);
+        $archive->setData(['id' => 10, 'deleted' => true, 'archived' => false, 'file_location' => $file]);
+
+        $archiveResource = $this->prophesize(ArchiveResource::class);
+        $archiveResource->getBySourceId('AE53J6FFSTT33H')->willReturn($archive);
+
+        $filter = new SkipUnchangedRecordsFromLastImport(
+            $importHistoryResource->reveal(),
+            $archiveResource->reveal(),
+            $this->directoryList,
+            new SourceFactory($this->prophesize(ObjectManagerInterface::class)->reveal()),
+            new SourceConsumer(),
+        );
+
+        $filter->prepare($config);
+
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Austria', 'code' => 'AT'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'United Kingdom', 'code' => 'UK'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Turkey', 'code' => 'TR'])));
+        self::assertTrue($filter->__invoke(new Record(0, ['country' => 'France', 'code' => 'FR'])));
+    }
+}

--- a/test/Filter/SkipUnchangedRecordsFromLastImportTest.php
+++ b/test/Filter/SkipUnchangedRecordsFromLastImportTest.php
@@ -42,7 +42,6 @@ class SkipUnchangedRecordsFromLastImportTest extends TestCase
         $this->directoryList = new DirectoryList($this->tempRoot);
     }
 
-
     public function testUnchangedRecordsAreSkipped() : void
     {
         $data = [
@@ -157,7 +156,6 @@ class SkipUnchangedRecordsFromLastImportTest extends TestCase
         self::assertTrue($filter->__invoke(new Record(0, ['country' => 'Turkey', 'code' => 'TR'])));
         self::assertTrue($filter->__invoke(new Record(0, ['country' => 'France', 'code' => 'FR'])));
     }
-
 
     public function testAllRecordsAreProcessedIfNoPreviousFileExists() : void
     {

--- a/test/Source/SourceConsumerTest.php
+++ b/test/Source/SourceConsumerTest.php
@@ -23,13 +23,12 @@ class SourceConsumerTest extends TestCase
         $consumer = new SourceConsumer();
         $data = $consumer->toArray($source, new Config('my-stock-import', ['id_field' => 'sku']));
 
-        self::assertEquals(['PROD1', 'PROD2', 'PROD3'], array_keys($data));
-        self::assertInstanceOf(Record::class, $data['PROD1']);
-        self::assertInstanceOf(Record::class, $data['PROD2']);
-        self::assertInstanceOf(Record::class, $data['PROD3']);
+        self::assertInstanceOf(Record::class, $data[0]);
+        self::assertInstanceOf(Record::class, $data[1]);
+        self::assertInstanceOf(Record::class, $data[2]);
 
-        self::assertEquals(['sku' => 'PROD1', 'stock' => 10], $data['PROD1']->asArray());
-        self::assertEquals(['sku' => 'PROD2', 'stock' => 5], $data['PROD2']->asArray());
-        self::assertEquals(['sku' => 'PROD3', 'stock' => 11], $data['PROD3']->asArray());
+        self::assertEquals(['sku' => 'PROD1', 'stock' => 10], $data[0]->asArray());
+        self::assertEquals(['sku' => 'PROD2', 'stock' => 5], $data[1]->asArray());
+        self::assertEquals(['sku' => 'PROD3', 'stock' => 11], $data[2]->asArray());
     }
 }


### PR DESCRIPTION
Introduce a new import filter, which, at the beginning of an import, will load the file from the very last import of the same name/type as the one processing. It will hash each row of the previous import and keep a copy of the data in memory. 

For each row in the new import, we hash it and check if the hash exists already (in the previous dataset) if it does, we skip it. We essentially produce a delta, on the fly.