### PR TITLE
Give writers more context of the import being ran

### DIFF
--- a/src/Import/Importer.php
+++ b/src/Import/Importer.php
@@ -194,7 +194,7 @@ class Importer
         $this->prepareComponents($config, $this->filters);
         $this->prepareComponents($config, $this->transformers);
 
-        $this->writer->prepare($this->source);
+        $this->writer->prepare($this->source, $config);
 
         $this->indexer->disable($config);
     }

--- a/src/Writer/CollectingWriter.php
+++ b/src/Writer/CollectingWriter.php
@@ -6,6 +6,7 @@ use Jh\Import\Import\Record;
 use Jh\Import\Import\Result;
 use Jh\Import\Report\ReportItem;
 use Jh\Import\Source\Source;
+use Jh\Import\Config;
 
 /**
  * @author Aydin Hassan <aydin@wearejh.com>
@@ -19,7 +20,7 @@ class CollectingWriter implements Writer
 
     private $affectedIds = [];
 
-    public function prepare(Source $source)
+    public function prepare(Source $source, Config $config)
     {
         // noop
     }

--- a/src/Writer/ProductWriter.php
+++ b/src/Writer/ProductWriter.php
@@ -7,6 +7,7 @@ use Jh\Import\AttributeProcessor\AttributeProcessor;
 use Jh\Import\Import\Result;
 use Jh\Import\Report\ReportItem;
 use Jh\Import\Source\Source;
+use Jh\Import\Config;
 use Magento\Catalog\Api\CategoryLinkManagementInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -212,7 +213,7 @@ class ProductWriter implements Writer
         }
     }
 
-    public function prepare(Source $source)
+    public function prepare(Source $source, Config $config)
     {
         $this->updatedProductsIds = [];
 

--- a/src/Writer/StockWriter.php
+++ b/src/Writer/StockWriter.php
@@ -8,6 +8,7 @@ use Jh\Import\Import\Record;
 use Jh\Import\Import\Result;
 use Jh\Import\Report\ReportItem;
 use Jh\Import\Source\Source;
+use Jh\Import\Config;
 use Jh\Import\Writer\Utils\DisableEventObserver;
 use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\CatalogInventory\Api\StockItemRepositoryInterface;
@@ -73,7 +74,7 @@ class StockWriter implements Writer
         $this->skusToIds = $this->adapter->fetchPairs($select);
     }
 
-    public function prepare(Source $source)
+    public function prepare(Source $source, Config $config)
     {
         $this->disableEventObserver->disable('clean_cache_by_tags', 'invalidate_varnish');
 

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -6,13 +6,14 @@ use Jh\Import\Import\Record;
 use Jh\Import\Import\Result;
 use Jh\Import\Report\ReportItem;
 use Jh\Import\Source\Source;
+use Jh\Import\Config;
 
 /**
  * @author Aydin Hassan <aydin@wearejh.com>
  */
 interface Writer
 {
-    public function prepare(Source $source);
+    public function prepare(Source $source, Config $config);
 
     public function write(Record $record, ReportItem $report);
 

--- a/test/Import/ImporterTest.php
+++ b/test/Import/ImporterTest.php
@@ -16,6 +16,7 @@ use Jh\Import\Locker\Locker;
 use Jh\Import\Progress\Progress;
 use Jh\Import\Report\Handler\CollectingHandler;
 use Jh\Import\Report\Report;
+use Jh\Import\Report\ReportItem;
 use Jh\Import\Report\ReportFactory;
 use Jh\Import\Report\ReportPersister;
 use Jh\Import\Source\Iterator;
@@ -55,7 +56,8 @@ class ImporterTest extends TestCase
             'writer'  => $writer->reveal()
         ]);
 
-        $writer->prepare(Argument::type(Source::class))->shouldBeCalled();
+        $writer->prepare(Argument::type(Source::class), $config)->shouldBeCalled();
+        $writer->write(Argument::type(Record::class), Argument::type(ReportItem::class))->shouldBeCalled();
         $writer->finish(Argument::type(Source::class))->willReturn(new Result([]))->shouldBeCalled();
 
         $importer->process($config);
@@ -63,7 +65,7 @@ class ImporterTest extends TestCase
 
     public function testIndexersAreDisabledAtStartAndIndexedAtEnd(): void
     {
-        $config  = new Config('product', []);
+        $config  = new Config('product', ['id_field' => 'sku']);
         $om      = $this->prophesize(ObjectManagerInterface::class);
         $writer  = $this->prophesize(Writer::class);
         $history = $this->prophesize(History::class);
@@ -90,7 +92,8 @@ class ImporterTest extends TestCase
 
         $result = new Result([1, 2, 3]);
 
-        $writer->prepare(Argument::type(Source::class))->shouldBeCalled();
+        $writer->prepare(Argument::type(Source::class), $config)->shouldBeCalled();
+        $writer->write(Argument::type(Record::class), Argument::type(ReportItem::class))->shouldBeCalled();
         $writer->finish(Argument::type(Source::class))->willReturn($result)->shouldBeCalled();
 
         $importer->process($config);
@@ -367,7 +370,7 @@ class ImporterTest extends TestCase
 
     public function testAddFilterCallsPrepareIfNecessary(): void
     {
-        $config  = new Config('product', []);
+        $config  = new Config('product', ['id_field' => 'sku']);
         $om      = $this->prophesize(ObjectManagerInterface::class);
         $history = $this->prophesize(History::class);
         $history->isImported(Argument::type(Source::class))->willReturn(false);
@@ -385,6 +388,7 @@ class ImporterTest extends TestCase
         ]);
 
         $callable = $this->prophesize(\Jh\ImportTest\Asset\CallablePrep::class);
+        $callable->__invoke(Argument::type(Record::class), Argument::type(ReportItem::class))->shouldBeCalled();
         $callable->prepare($config)->shouldBeCalled();
 
         $importer->filter($callable->reveal());
@@ -393,7 +397,7 @@ class ImporterTest extends TestCase
 
     public function testAddTransformerCallsPrepareIfNecessary(): void
     {
-        $config  = new Config('product', []);
+        $config  = new Config('product', ['id_field' => 'sku']);
         $om      = $this->prophesize(ObjectManagerInterface::class);
         $history = $this->prophesize(History::class);
         $history->isImported(Argument::type(Source::class))->willReturn(false);
@@ -411,6 +415,7 @@ class ImporterTest extends TestCase
         ]);
 
         $callable = $this->prophesize(\Jh\ImportTest\Asset\CallablePrep::class);
+        $callable->__invoke(Argument::type(Record::class), Argument::type(ReportItem::class))->shouldBeCalled();
         $callable->prepare($config)->shouldBeCalled();
 
         $importer->transform($callable->reveal());

--- a/test/Writer/StockWriterTest.php
+++ b/test/Writer/StockWriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jh\ImportTest\Writer;
 
+use Jh\Import\Config;
 use Jh\Import\Import\Record;
 use Jh\Import\Report\CollectingReport;
 use Jh\Import\Report\Handler\CollectingHandler;
@@ -210,7 +211,10 @@ class StockWriterTest extends TestCase
             $disableEventObserver = new DisableEventObserver()
         );
 
-        $writer->prepare($this->prophesize(Source::class)->reveal());
+        $writer->prepare(
+            $this->prophesize(Source::class)->reveal(),
+            $this->prophesize(Config::class)->reveal(),
+        );
 
         self::assertSame(
             ['clean_cache_by_tags' => ['invalidate_varnish']],


### PR DESCRIPTION
Currently Writers are "dumb" which isn't a bad thing but in a recent scenario I needed the writer to have some data of the import it was writing for. 

The specific scenario was writing the data to a db table to be collated later but the row being written had to include the import name to prevent duping. 

It also turned out that a few tests were failing on my local due to how PHP error handling was configured. All going well the changes should allow tests to run in both a dev / prod error reporting configuration. 