### PR TITLE
Add support for using DB connection as data source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
     "description": "Import module for Magento 2 - provides commands, utilities and abstractions for building imports for Magento 2 projects",
     "type": "magento2-module",
     "require": {
-        "php": "^7.3",
+        "php": ">=7.4",
         "ext-json": "*",
+        "ext-pdo": "*",
         "tightenco/collect": "^7.2",
         "trash-panda/progress-bar-log": "^1.5",
         "magento/framework": ">=103",

--- a/src/Config.php
+++ b/src/Config.php
@@ -78,6 +78,26 @@ class Config
         return $this->config['cron_group'] ?? null;
     }
 
+    public function getConnectionName(): ?string
+    {
+        return $this->config['connection_name'] ?? null;
+    }
+
+    public function getSourceId(): ?string
+    {
+        return $this->config['source_id'] ?? null;
+    }
+
+    public function getSelectSql(): ?string
+    {
+        return $this->config['select_sql'] ?? null;
+    }
+
+    public function getCountSql(): ?string
+    {
+        return $this->config['count_sql'] ?? null;
+    }
+
     /**
      * @param string $key
      * @return string|null

--- a/src/Config/Converter.php
+++ b/src/Config/Converter.php
@@ -24,6 +24,18 @@ class Converter implements ConverterInterface
             'cron_group' => ['type' => 'string', 'default' => 'default'],
             'archive_old_files' => ['type' => 'bool', 'default' => false],
             'delete_old_files' => ['type' => 'bool', 'default' => false],
+        ],
+        'db' => [
+            'connection_name' => ['type' => 'string'],
+            'source' => ['type' => 'string'],
+            'specification' => ['type' => 'string'],
+            'writer' => ['type' => 'string'],
+            'id_field' => ['type' => 'string'],
+            'source_id' => ['type' => 'string'],
+            'select_sql' => ['type' => 'string'],
+            'count_sql' => ['type' => 'string'],
+            'cron' => ['type' => 'string'],
+            'cron_group' => ['type' => 'string', 'default' => 'default']
         ]
     ];
 

--- a/src/Import/Manager.php
+++ b/src/Import/Manager.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
 
 namespace Jh\Import\Import;
 
 use Jh\Import\Config\Data;
+use Jh\Import\Type\Db;
 use Jh\Import\Type\Files;
 use Jh\Import\Type\Type;
 use Magento\Framework\ObjectManagerInterface;
@@ -15,20 +17,21 @@ class Manager
     /**
      * @var Data
      */
-    private $config;
+    private Data $config;
 
     /**
      * @var ObjectManagerInterface
      */
-    private $objectManager;
+    private ObjectManagerInterface $objectManager;
 
     /**
      * Pull this from config
      *
      * @var array
      */
-    private $types = [
-        'files' => Files::class
+    private array $types = [
+        'files' => Files::class,
+        'db' => Db::class
     ];
 
     public function __construct(Data $config, ObjectManagerInterface $objectManager)

--- a/src/Progress/CliProgress.php
+++ b/src/Progress/CliProgress.php
@@ -4,7 +4,6 @@ namespace Jh\Import\Progress;
 
 use Jh\Import\Config;
 use Jh\Import\Source\Source;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use TrashPanda\ProgressBarLog\ProgressBarLog;
 

--- a/src/Source/Db.php
+++ b/src/Source/Db.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Jh\Import\Source;
+
+use Countable;
+use Jh\Import\Report\Report;
+use Magento\Framework\App\ResourceConnection;
+use PDO;
+use Zend_Exception;
+
+/**
+ * @author Maciej Sławik <maciej@wearejh.com>
+ */
+class Db implements Source, Countable
+{
+    private ResourceConnection $resourceConnection;
+    private string $connectionName;
+    private string $sourceId;
+    private string $selectSql;
+    private string $countSql;
+    private string $idField;
+
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        string $connectionName,
+        string $sourceId,
+        string $selectSql,
+        string $countSql,
+        string $idField
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->connectionName = $connectionName;
+        $this->sourceId = $sourceId . time();
+        $this->selectSql = $selectSql;
+        $this->countSql = $countSql;
+        $this->idField = $idField;
+    }
+
+    public function traverse(callable $onSuccess, callable $onError, Report $report): void
+    {
+        try {
+            foreach ($this->iterateSet() as $row) {
+                $onSuccess($row[$this->idField], $row);
+            }
+        } catch (Zend_Exception $e) {
+            $report->addError($e->getMessage());
+            $onError(null);
+        }
+    }
+
+    public function getSourceId(): string
+    {
+        return $this->sourceId;
+    }
+
+    public function count()
+    {
+        $connection = $this->resourceConnection->getConnection($this->connectionName);
+        $count = $connection->fetchOne($this->countSql);
+        return (int) $count;
+    }
+
+    private function iterateSet()
+    {
+        $connection = $this->resourceConnection->getConnection($this->connectionName);
+        $query = $connection->query($this->selectSql);
+        while ($row = $query->fetch(PDO::FETCH_ASSOC)) {
+            yield $row;
+        }
+    }
+}

--- a/src/Type/Db.php
+++ b/src/Type/Db.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Jh\Import\Type;
+
+use Jh\Import\Config;
+use Jh\Import\Import\ImporterFactory;
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * @author Maciej Sławik <maciej@wearejh.com>
+ */
+class Db implements Type
+{
+    private ObjectManagerInterface $objectManager;
+    private ImporterFactory $importerFactory;
+
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        ImporterFactory $importerFactory
+    ) {
+        $this->objectManager = $objectManager;
+        $this->importerFactory = $importerFactory;
+    }
+
+    public function run(Config $config)
+    {
+        $specification = $this->objectManager->get($config->getSpecificationService());
+        $writer = $this->objectManager->get($config->getWriterService());
+        $source = $this->objectManager->create($config->getSourceService(), [
+            'connectionName' => (string) $config->getConnectionName(),
+            'idField' => $config->getIdField(),
+            'sourceId' => (string) $config->getSourceId(),
+            'selectSql' => (string) $config->getSelectSql(),
+            'countSql' => (string) $config->getCountSql()
+        ]);
+
+        $this->importerFactory
+            ->create($source, $specification, $writer)
+            ->process($config);
+    }
+}

--- a/src/etc/imports.xsd
+++ b/src/etc/imports.xsd
@@ -4,6 +4,7 @@
         <xs:complexType>
             <xs:choice maxOccurs="unbounded">
                 <xs:element name="files" type="filesType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="db" type="dbType" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
         </xs:complexType>
     </xs:element>
@@ -40,6 +41,40 @@
             </xs:element>
             <xs:element name="archive_old_files" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
             <xs:element name="delete_old_files" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+    <xs:complexType name="dbType" >
+        <xs:annotation>
+            <xs:documentation>
+                An import who's source is a DB
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="connection_name" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="source" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="specification" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="writer" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="id_field" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="source_id" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="select_sql" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="count_sql" minOccurs="1" maxOccurs="1" type="xs:string"/>
+            <xs:element name="cron" minOccurs="0" maxOccurs="1" type="xs:string"/>
+            <xs:element name="cron_group" minOccurs="0" maxOccurs="1" type="xs:string"/>
+            <xs:element name="indexers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="indexer" minOccurs="1" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="report_handlers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="report_handler" minOccurs="1" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>


### PR DESCRIPTION
### Feature/Issue Description

Right now the module only supports CSV files as data source. I added support for DB connection as a data source.

### Code Explanation

* src/Ui/Component/Listing/ImportSearchResult.php - had to update this file because it was not compatible with M2.4
* See README I guess


### TODOs

- [x] Add DB support 
- [x] Update README 


---

![Yay!](https://camo.githubusercontent.com/f34adf29ec729fc3fdda9cc4b8ef6d35f8d9dcda/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f78644b6934666b494f315952792f67697068792e676966)
