### PR TITLE
Allow CLI output in redirected STDOUT

### DIFF
--- a/src/Output/Factory.php
+++ b/src/Output/Factory.php
@@ -24,7 +24,7 @@ class Factory
 
     public function get(): OutputInterface
     {
-        if ($this->appState->getMode() === State::MODE_DEVELOPER || posix_isatty(STDOUT)) {
+        if ($this->appState->getMode() === State::MODE_DEVELOPER || PHP_SAPI === 'cli') {
             return $this->getConsoleOutput();
         }
 

--- a/src/Report/ReportFactory.php
+++ b/src/Report/ReportFactory.php
@@ -34,7 +34,7 @@ class ReportFactory
 
         $appState = $this->objectManager->get(State::class);
 
-        if ($appState->getMode() === State::MODE_DEVELOPER || posix_isatty(STDOUT)) {
+        if ($appState->getMode() === State::MODE_DEVELOPER || PHP_SAPI === 'cli') {
             $handlers[] = $this->objectManager->create(ConsoleHandler::class, [
                 'minErrorLevel' => LogLevel::WARNING
             ]);


### PR DESCRIPTION
The module uses the `posix_isatty(STDOUT)` method (in non development mode) to detect whether someone ran a command from the CLI or not.

It may happen (and it is my use case) that I want to keep the command's output but need to redirect it somewhere else.

For example: bin/magento jh-import:run import-name > output.txt
Or use a third-party tool - like [Rundeck](https://www.rundeck.com) or [GoCD](https://www.gocd.org)

In this case, the output is empty.

My pull-request changes the CLI detection method to `PHP_SAPI=='cli'` for reports and keeps the progress bar only for unredirected STDOUT.