### PR TITLE
Fix Undefined array key

### DIFF
--- a/src/Writer/ProductWriter.php
+++ b/src/Writer/ProductWriter.php
@@ -218,13 +218,13 @@ class ProductWriter implements Writer
         $this->updatedProductsIds = [];
 
         //force load of plugins
-        $this->pluginList->getNext(Product::class, 'save');
+        $this->pluginList->getNext(ProductResource::class, 'save');
 
         $r = new \ReflectionProperty(PluginList::class, '_processed');
         $r->setAccessible(true);
 
         $processed     = $r->getValue($this->pluginList);
-        $methodKey     = sprintf('%s_save___self', Product::class);
+        $methodKey     = sprintf('%s_save___self', ProductResource::class);
         $pluginNameKey = array_search('clean_cache', $processed[$methodKey], true);
         unset($processed[$methodKey][$pluginNameKey]);
         $r->setValue($this->pluginList, $processed);


### PR DESCRIPTION
Fixes error:

```
Warning: Undefined array key "Magento\Catalog\Model\Product_save___self" in /vendor/wearejh/m2-module-import/src/Writer/ProductWriter.php on line 229
```

* Magento 2.4.5
* m2-module-import 2.4.2
