### PR TITLE
Fix for pagination calculation error

### DIFF
--- a/src/Source/Webapi.php
+++ b/src/Source/Webapi.php
@@ -44,7 +44,7 @@ class Webapi implements Source, Countable
         ?FilterDecoratorInterface $dataRequestFilterDecorator = null
     ) {
         $this->idField = $idField;
-        $this->sourceId = $sourceId;
+        $this->sourceId = sprintf('%s_%s', $sourceId, date('Y_m_d H:i:s'));
         $this->pagingManager = $pagingManager;
         $this->countRequestFactory = $countRequestFactory;
         $this->countResponseHandler = $countResponseHandler;
@@ -71,7 +71,7 @@ class Webapi implements Source, Countable
     public function traverse(callable $onSuccess, callable $onError, Report $report): void
     {
         try {
-            $totalNumberOfItems = $this->count();
+            $totalNumberOfItems = $this->countAll();
             $pagesAmount = ceil($totalNumberOfItems / $this->dataRequestPageSize);
 
             for (
@@ -96,6 +96,12 @@ class Webapi implements Source, Countable
     public function getSourceId(): string
     {
         return $this->sourceId;
+    }
+
+    private function countAll(): int
+    {
+        $response = $this->httpClient->sendRequest($this->countRequestFactory->create());
+        return $this->countResponseHandler->handle($response);
     }
 
     private function getPageToStartFrom(): int


### PR DESCRIPTION
Fix for pagination calculation error. Example - we run out of memory on 28th page of webapi endpoint, but we have 6 pages left. Before the fix these pages were ommited due to comparing start page to pages left calculated from remaining items. From now on we compare to global pages amount, so in that case 34.