### PR TITLE
feature/JDTB-167-fix-preference-issue

### DIFF
--- a/src/Output/Factory.php
+++ b/src/Output/Factory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jh\Import\Output;
 
 use Magento\Framework\App\State;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -27,14 +26,9 @@ class Factory
     public function get(): OutputInterface
     {
         if ($this->appState->getMode() === State::MODE_DEVELOPER || PHP_SAPI === 'cli') {
-            return $this->getConsoleOutput();
+            return $this->output;
         }
 
         return new NullOutput();
-    }
-
-    public function getConsoleOutput(): ConsoleOutput
-    {
-        return $this->output;
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,7 +25,6 @@
             <argument name="cacheId" xsi:type="string">jh_import_config_cache</argument>
         </arguments>
     </type>
-    <preference for="Symfony\Component\Console\Output\OutputInterface" type="Symfony\Component\Console\Output\ConsoleOutput" />
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
**Ticket**: JDTB-167

**Description**:

Magento 2.4.8 Allow only valid preferences during setup:di:compile.

I believe issue is OutputInterface preference in di.xml is redundant because if we check ConsoleOutput class(https://github.com/symfony/console/blob/7.3/Output/ConsoleOutput.php) which extends StreamOutput and implements ConsoleOutputInterface and ConsoleOutputInterface implements OutputInterfacehttps://github.com/symfony/console/blob/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7/Output/ConsoleOutputInterface.php#L20

In Factory class, there's a type mismatch in getConsoleOutput() mentioned, we're injecting OutputInterface but trying to return ConsoleOutput
This is also cause type compatibility issues.

**Changes**:
I have removed the preference from di.xml and also using correct type hints in Factory class and tried to run compilation command and it works fine.