### PR TITLE
JDTB-168 Fix level names

### DIFF
--- a/src/Ui/Component/Listing/Column/Level/Options.php
+++ b/src/Ui/Component/Listing/Column/Level/Options.php
@@ -17,11 +17,22 @@ class Options implements OptionSourceInterface
 
     public function toOptionArray(): array
     {
+        $levels = [
+            'DEBUG' => Logger::DEBUG,
+            'INFO' => Logger::INFO,
+            'NOTICE' => Logger::NOTICE,
+            'WARNING' => Logger::WARNING,
+            'ERROR' => Logger::ERROR,
+            'CRITICAL' => Logger::CRITICAL,
+            'ALERT' => Logger::ALERT,
+            'EMERGENCY' => Logger::EMERGENCY,
+        ];
+
         return array_map(function ($levelName) {
             return [
                 'value' => $levelName,
                 'label' => $levelName,
             ];
-        }, array_keys(Logger::getLevels()));
+        }, array_keys($levels));
     }
 }


### PR DESCRIPTION
**Ticket**: JDTB-168


**Description:**
As per Magento 2.4.8 version in which monolog version has been upgraded to "monolog/monolog": "^3.6" and it doesn’t support in previous version as it doesn't have getLevels() anymore so according to https://github.com/Seldaek/monolog/blob/main/CHANGELOG.md#300-rc1-2022-05-08.

 I have used Logger class as it’s available in both version of Magento and get all Level constants from the Logger file https://github.com/Seldaek/monolog/blob/main/src/Monolog/Logger.php

**Demo:**
<img width="1300" height="572" alt="Screenshot 2025-08-28 at 09 27 24" src="https://github.com/user-attachments/assets/8d16cd4d-71ae-49f8-9f67-8a3cd8fcd596" />
