### PR TITLE
WOOD-3176 allow string|int compat php 7.4 & 8

### DIFF
--- a/src/Import/Record.php
+++ b/src/Import/Record.php
@@ -2,6 +2,8 @@
 
 namespace Jh\Import\Import;
 
+use RuntimeException;
+
 class Record
 {
     /**
@@ -20,6 +22,12 @@ class Record
      */
     public function __construct($rowNumber, array $data = [])
     {
+        if (!is_int($rowNumber) && !is_string($rowNumber)) {
+            throw new RuntimeException(
+                sprintf('Argument #1 $rowNumber must be of type int or string, %s given', gettype($rowNumber))
+            );
+        }
+
         $this->rowNumber = $rowNumber;
         $this->data = $data;
     }
@@ -64,7 +72,7 @@ class Record
         $value = $this->data[$columnName] ?? $default;
 
         if ($dataType && gettype($value) !== $dataType) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf(
                     'Value of "%s" data type: "%s" does not match expected: "%s"',
                     $columnName,

--- a/src/Import/Record.php
+++ b/src/Import/Record.php
@@ -5,7 +5,7 @@ namespace Jh\Import\Import;
 class Record
 {
     /**
-     * @var int
+     * @var int|string
      */
     private $rowNumber;
 
@@ -14,13 +14,20 @@ class Record
      */
     private $data;
 
-    public function __construct(int $rowNumber, array $data = [])
+    /**
+     * @param int|string $rowNumber
+     * @param array $data
+     */
+    public function __construct($rowNumber, array $data = [])
     {
         $this->rowNumber = $rowNumber;
         $this->data = $data;
     }
 
-    public function getRowNumber(): int
+    /**
+     * @return int|string
+     */
+    public function getRowNumber()
     {
         return $this->rowNumber;
     }


### PR DESCRIPTION
As part of https://wearejh.atlassian.net/browse/WOOD-3176 I need to allow rowNumber to be a string or int so I can use the following SQL which will get me all the qtys and ids for each store from an SKU. 

This then will allow me to process by each product rather than each row and stop race conditions. 

```
            SELECT
                lrs.sku,
                GROUP_CONCAT(
                    CONCAT(lrs.store_id, ': ', lrs.qty)
                    ORDER BY lrs.store_id
                    SEPARATOR ', '
                ) AS store_qtys,
                GROUP_CONCAT(
                    lrs.id
                    ORDER BY lrs.store_id
                    SEPARATOR ', '
                ) AS stock_ids
            FROM ls_retail_stock AS lrs
            WHERE (lrs.imported_at < lrs.updated_at OR lrs.imported_at IS NULL)
              AND NOT EXISTS (
                  SELECT 1
                  FROM stock_processing_status AS sps
                  WHERE sps.sku = lrs.sku
                    AND sps.store = lrs.store_id
              )
            GROUP BY lrs.sku;
```

<img width="1106" height="69" alt="Screenshot 2026-03-17 at 17 34 16" src="https://github.com/user-attachments/assets/3c33fd65-899f-4cef-9915-a0482f7e7fea" />