### PR TITLE
PHP 8.4/8.5, Symfony 7 & Magento 2.4.9 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Import module for Magento 2 - provides commands, utilities and abstractions for building imports for Magento 2 projects",
     "type": "magento2-module",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": ">=7.4",
         "ext-json": "*",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.4",
@@ -13,8 +13,8 @@
         "magento/module-configurable-product": ">=100.4",
         "psr/http-client": "*",
         "psr/http-message": "*",
-        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "tightenco/collect": "^8.0 || ^9.0"
+        "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "illuminate/collections": "^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
         "monolog/monolog": "^1.22 || ^2.1",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Import module for Magento 2 - provides commands, utilities and abstractions for building imports for Magento 2 projects",
     "type": "magento2-module",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.4",

--- a/src/Archiver/CsvArchiver.php
+++ b/src/Archiver/CsvArchiver.php
@@ -50,7 +50,7 @@ class CsvArchiver implements Archiver
         DirectoryList $directoryList,
         File $filesystem,
         ResourceConnection $resourceConnection,
-        DateTime $date = null
+        ?DateTime $date = null
     ) {
         $this->source = $source;
         $this->config = $config;

--- a/src/Command/ClearLastImportLogCommand.php
+++ b/src/Command/ClearLastImportLogCommand.php
@@ -49,7 +49,7 @@ class ClearLastImportLogCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $input->setInteractive(true);
         $importName = $input->getArgument('import_name');

--- a/src/Command/ListImportsCommand.php
+++ b/src/Command/ListImportsCommand.php
@@ -53,7 +53,7 @@ class ListImportsCommand extends Command
             ->setDescription('List all of the registered imports');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $input->setInteractive(true);
 

--- a/src/Command/RunImportCommand.php
+++ b/src/Command/RunImportCommand.php
@@ -40,7 +40,7 @@ class RunImportCommand extends Command
             ->addArgument('import_name', InputArgument::REQUIRED, 'The import to run as defined in imports.xml');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $this->state->setAreaCode('crontab');

--- a/src/Command/UnlockImportCommand.php
+++ b/src/Command/UnlockImportCommand.php
@@ -39,7 +39,7 @@ class UnlockImportCommand extends Command
             ->addArgument('import_name', InputArgument::REQUIRED, 'The import to run as defined in imports.xml');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $importName = $input->getArgument('import_name');
 

--- a/src/Command/ViewLocksCommand.php
+++ b/src/Command/ViewLocksCommand.php
@@ -35,7 +35,7 @@ class ViewLocksCommand extends Command
             ->setDescription('Show current locks');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $locks = array_map(
             function (string $importName) {
@@ -51,7 +51,7 @@ class ViewLocksCommand extends Command
 
         if (empty($locks)) {
             $output->writeln(['', '<comment>No import is locked</comment>', '']);
-            return;
+            return Cli::RETURN_SUCCESS;
         }
 
         $output->writeln('');

--- a/src/Command/ViewLogsCommand.php
+++ b/src/Command/ViewLogsCommand.php
@@ -47,7 +47,7 @@ class ViewLogsCommand extends Command
             ->addArgument('num_logs', InputArgument::OPTIONAL, 'The number of import logs to show');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $input->setInteractive(true);
         $importName = $input->getArgument('import_name');

--- a/src/Exception/UnexpectedResponseException.php
+++ b/src/Exception/UnexpectedResponseException.php
@@ -17,7 +17,7 @@ class UnexpectedResponseException extends LocalizedException implements ClientEx
     public function __construct(
         Phrase $phrase,
         ResponseInterface $response,
-        Exception $cause = null,
+        ?Exception $cause = null,
         $code = 0
     ) {
         parent::__construct($phrase, $cause, $code);

--- a/src/Import/Record.php
+++ b/src/Import/Record.php
@@ -67,7 +67,7 @@ class Record
         $this->data = $data;
     }
 
-    public function getColumnValue(string $columnName, $default = null, string $dataType = null)
+    public function getColumnValue(string $columnName, $default = null, ?string $dataType = null)
     {
         $value = $this->data[$columnName] ?? $default;
 
@@ -85,7 +85,7 @@ class Record
         return $value;
     }
 
-    public function getColumnValueAndUnset(string $columnName, $default = null, string $dataType = null)
+    public function getColumnValueAndUnset(string $columnName, $default = null, ?string $dataType = null)
     {
         $value = $this->getColumnValue($columnName, $default, $dataType);
         $this->unset($columnName);
@@ -113,7 +113,7 @@ class Record
         $this->unset($columnFrom);
     }
 
-    public function moveColumnToArray(string $columnFrom, string $columnTo, string $key = null): void
+    public function moveColumnToArray(string $columnFrom, string $columnTo, ?string $key = null): void
     {
         if (null === $key) {
             $key = $columnFrom;

--- a/src/Report/Message.php
+++ b/src/Report/Message.php
@@ -24,7 +24,7 @@ class Message
      */
     private $dateTime;
 
-    public function __construct(string $logLevel, string $message, \DateTime $dateTime = null)
+    public function __construct(string $logLevel, string $message, ?\DateTime $dateTime = null)
     {
         $this->logLevel = $logLevel;
         $this->message = $message;

--- a/src/Report/Report.php
+++ b/src/Report/Report.php
@@ -57,7 +57,7 @@ class Report
         $this->handlers[] = $handler;
     }
 
-    public function start(\DateTime $startTime = null)
+    public function start(?\DateTime $startTime = null)
     {
         $startTime = $startTime ?: new \DateTime();
         foreach ($this->handlers as $handler) {
@@ -115,7 +115,7 @@ class Report
         }
     }
 
-    public function finish(\DateTime $finishTime = null, int $memoryUsage = null): void
+    public function finish(?\DateTime $finishTime = null, ?int $memoryUsage = null): void
     {
         $finishTime  = $finishTime ?: new \DateTime();
         $memoryUsage = $memoryUsage ?: memory_get_usage(true);

--- a/src/Transformer/ProductVisibilityTransformer.php
+++ b/src/Transformer/ProductVisibilityTransformer.php
@@ -27,7 +27,7 @@ class ProductVisibilityTransformer
      */
     private $defaultVisibilityId;
 
-    public function __construct(string $column, int $defaultVisibilityId = null)
+    public function __construct(string $column, ?int $defaultVisibilityId = null)
     {
         $this->column  = $column;
         $this->options = collect(Visibility::getOptionArray())

--- a/src/Ui/Component/Listing/ImportSearchResult.php
+++ b/src/Ui/Component/Listing/ImportSearchResult.php
@@ -48,8 +48,8 @@ class ImportSearchResult extends AbstractCollection implements SearchResultInter
         LoggerInterface $logger,
         FetchStrategyInterface $fetchStrategy,
         ManagerInterface $eventManager,
-        AdapterInterface $connection = null,
-        AbstractDb $resource = null
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null
     ) {
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
         $this->setItemObjectClass(Document::class);
@@ -79,7 +79,7 @@ class ImportSearchResult extends AbstractCollection implements SearchResultInter
      * @param DocumentInterface[] $items
      * @return $this
      */
-    public function setItems(array $items = null): self
+    public function setItems(?array $items = null): self
     {
         if (!$items) {
             return $this;

--- a/src/Writer/ProductWriter.php
+++ b/src/Writer/ProductWriter.php
@@ -221,7 +221,6 @@ class ProductWriter implements Writer
         $this->pluginList->getNext(ProductResource::class, 'save');
 
         $r = new \ReflectionProperty(PluginList::class, '_processed');
-        $r->setAccessible(true);
 
         $processed     = $r->getValue($this->pluginList);
         $methodKey     = sprintf('%s_save___self', ProductResource::class);


### PR DESCRIPTION
## Summary
Compatibility fixes for PHP 8.4/8.5, Symfony 7 and Magento 2.4.9.

- **PHP 8.4** — explicit nullable type declarations (`?Type`) for params with a `null` default, fixing the implicit-nullable deprecation across `Command`, `Archiver`, `Exception`, `Import`, `Report`, `Transformer`, `Ui`.
- **Symfony 7** — `execute(): int` return types on console commands; allow `symfony/console ^7.0`.
- **PHP 8.5** — drop the no-op `ReflectionProperty::setAccessible()` call in `ProductWriter` (no-op since 8.1, deprecated in 8.5).
- **Dependency** — `tightenco/collect` is abandoned and caps PHP support; swapped to `illuminate/collections`. Namespace-transparent (both provide `Illuminate\Support\Collection`), so no code changes. Open to a different replacement if you prefer.

Tested on Magento 2.4.7–2.4.9 (PHP 8.1–8.5).