### PR TITLE
Guard CLI progress TTY detection when POSIX ext is unavailable

### DIFF
--- a/src/Progress/Factory.php
+++ b/src/Progress/Factory.php
@@ -26,11 +26,16 @@ class Factory
 
     public function get(): Progress
     {
-        if ($this->appState->getMode() === State::MODE_DEVELOPER || posix_isatty(STDOUT)) {
+        if ($this->appState->getMode() === State::MODE_DEVELOPER || $this->isInteractiveCliOutput()) {
             return $this->getCliProgress();
         }
 
         return new NullProgress();
+    }
+
+    private function isInteractiveCliOutput(): bool
+    {
+        return function_exists('posix_isatty') && posix_isatty(STDOUT);
     }
 
     public function getCliProgress(): CliProgress


### PR DESCRIPTION
## Summary
`Progress\Factory::get()` calls `posix_isatty(STDOUT)` directly. On PHP builds without the **posix** extension (some production CLI environments), this is an undefined function and fatals with *Call to undefined function* whenever the app is not in developer mode — breaking import crons.

The TTY check is wrapped in `function_exists('posix_isatty')` via a small `isInteractiveCliOutput()` helper. Without posix it falls back to `NullProgress`, the correct behaviour for a non-TTY/cron context. No change where posix is present.