### PR TITLE
Escape output in adminhtml import info templates

### DIFF
--- a/src/view/adminhtml/templates/import_info.phtml
+++ b/src/view/adminhtml/templates/import_info.phtml
@@ -1,28 +1,28 @@
 <div class="dashboard-container row">
     <div class="dashboard-secondary col-m-3">
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Import Name') ?></div>
-            <?= $this->getImport()->getImportName() ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Import Name')) ?></div>
+            <?= $escaper->escapeHtml($this->getImport()->getImportName()) ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Import Type') ?></div>
-            <?= $this->getImport()->getType() ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Import Type')) ?></div>
+            <?= $escaper->escapeHtml($this->getImport()->getType()) ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Lock Status') ?></div>
-            <?= $this->getLockStatus() ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Lock Status')) ?></div>
+            <?= $escaper->escapeHtml($this->getLockStatus()) ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Indexers') ?></div>
-            <?= implode(",\n", $this->getImport()->getIndexers()) ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Indexers')) ?></div>
+            <?= $escaper->escapeHtml(implode(",\n", $this->getImport()->getIndexers())) ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Report Handlers') ?></div>
-            <?= implode(",\n", $this->getImport()->getReportHandlers()) ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Report Handlers')) ?></div>
+            <?= $escaper->escapeHtml(implode(",\n", $this->getImport()->getReportHandlers())) ?>
         </div>
         <?php if ($this->hasCron()): ?>
             <div class="dashboard-item">
-                <div class="dashboard-item-title"><?=  __('Cron') ?></div>
+                <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Cron')) ?></div>
                 <div class="dashboard-item-content">
                     <table class="admin__table-primary">
                         <tbody>
@@ -30,17 +30,17 @@
                             <?php $expression = $this->getCronExpression() ?>
                             <td style="">Expression</td>
                             <td style="" class="last">
-                                <?= $expression ?>
-                                <br><small><a target="_blank" href="https://crontab.guru/#<?= str_replace(' ', '_', $expression) ?>">What does that mean?</a></small>
+                                <?= $escaper->escapeHtml($expression) ?>
+                                <br><small><a target="_blank" href="https://crontab.guru/#<?= $escaper->escapeHtml(str_replace(' ', '_', $expression)) ?>">What does that mean?</a></small>
                             </td>
                         </tr>
                         <tr>
                             <td style="">Cron group</td>
-                            <td style="" class="last"><?= $this->getCronGroup() ?></td>
+                            <td style="" class="last"><?= $escaper->escapeHtml($this->getCronGroup()) ?></td>
                         </tr>
                         <tr>
                             <td style="">Cron code</td>
-                            <td style="" class="last"><?= $this->getCronCode() ?></td>
+                            <td style="" class="last"><?= $escaper->escapeHtml($this->getCronCode()) ?></td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/view/adminhtml/templates/info_type_files.phtml
+++ b/src/view/adminhtml/templates/info_type_files.phtml
@@ -1,20 +1,20 @@
 <div class="dashboard-container row">
     <div class="dashboard-secondary col-m-3">
         <div class="dashboard-item" style="word-break: break-all">
-            <div class="dashboard-item-title"><?=  __('Incoming directory') ?></div>
-            <span><?= $this->incomingDirectory() ?></span>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Incoming directory')) ?></div>
+            <span><?= $escaper->escapeHtml($this->incomingDirectory()) ?></span>
         </div>
         <div class="dashboard-item" style="word-break: break-all">
-            <div class="dashboard-item-title"><?=  __('Archived directory') ?></div>
-            <span><?= $this->archivedDirectory() ?></span>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Archived directory')) ?></div>
+            <span><?= $escaper->escapeHtml($this->archivedDirectory()) ?></span>
         </div>
         <div class="dashboard-item" style="word-break: break-all">
-            <div class="dashboard-item-title"><?=  __('Failed directory: ') ?></div>
-            <span><?= $this->failedDirectory() ?></span>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Failed directory: ')) ?></div>
+            <span><?= $escaper->escapeHtml($this->failedDirectory()) ?></span>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?=  __('Files Match') ?></div>
-            <?= $this->getImport()->get('match_files') ?>
+            <div class="dashboard-item-title"><?=  $escaper->escapeHtml(__('Files Match')) ?></div>
+            <?= $escaper->escapeHtml($this->getImport()->get('match_files')) ?>
         </div>
     </div>
     <div class="dashboard-secondary col-m-7">
@@ -33,8 +33,10 @@
                             <?php foreach ($this->filesNew() as $file) : ?>
                                 <tr>
                                     <td style="width:70%">
-                                        <a href="<?= $this->getDeleteUrl($file, 'incoming_directory') ?>" class="action-delete"></a>
-                                        <a href="<?= $this->getDownloadUrl($file, 'incoming_directory') ?>"><?= $file->getRealPath() ?></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDeleteUrl($file, 'incoming_directory')) ?>" class="action-delete"></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDownloadUrl($file, 'incoming_directory')) ?>">
+                                            <?= $escaper->escapeHtml($file->getRealPath()) ?>
+                                        </a>
                                     </td>
                                     <td style="text-align:right;color:<?= $this->fileWillBeProcessed($file) ? 'green' : 'red' ?>"class="last" ><?= $this->fileWillBeProcessed($file) ? '✔' : '✘' ?></td>
                                 </tr>
@@ -61,10 +63,12 @@
                             <?php foreach ($files as $file) : ?>
                                 <tr>
                                     <td style="width:70%">
-                                        <a href="<?= $this->getDeleteUrl($file, 'archived_directory') ?>" class="action-delete"></a>
-                                        <a href="<?= $this->getDownloadUrl($file, 'archived_directory') ?>"><?= $file->getRealPath() ?></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDeleteUrl($file, 'archived_directory')) ?>" class="action-delete"></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDownloadUrl($file, 'archived_directory')) ?>">
+                                            <?= $escaper->escapeHtml($file->getRealPath()) ?>
+                                        </a>
                                     </td>
-                                    <td style="text-align:right" class="last"><?= $this->getChangeTime($file) ?></td>
+                                    <td style="text-align:right" class="last"><?= $escaper->escapeHtml($this->getChangeTime($file)) ?></td>
                                 </tr>
                             <?php endforeach ?>
                         </tbody>
@@ -90,10 +94,12 @@
                                 <?php /** @var $file \SplFileInfo */ ?>
                                 <tr>
                                     <td style="width:70%">
-                                        <a href="<?= $this->getDeleteUrl($file, 'failed_directory') ?>" class="action-delete"></a>
-                                        <a href="<?= $this->getDownloadUrl($file, 'failed_directory') ?>"><?= $file->getRealPath() ?></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDeleteUrl($file, 'failed_directory')) ?>" class="action-delete"></a>
+                                        <a href="<?= $escaper->escapeUrl($this->getDownloadUrl($file, 'failed_directory')) ?>">
+                                            <?= $escaper->escapeHtml($file->getRealPath()) ?>
+                                        </a>
                                     </td>
-                                    <td style="text-align:right" class="last"><?= $this->getChangeTime($file) ?></td>
+                                    <td style="text-align:right" class="last"><?= $escaper->escapeHtml($this->getChangeTime($file)) ?></td>
                                 </tr>
                             <?php endforeach ?>
                         </tbody>


### PR DESCRIPTION
## Summary
`import_info.phtml` and `info_type_files.phtml` echo values without escaping — flagged by the Magento2 coding standard and an XSS risk for attacker-influenced import metadata. Dynamic output is wrapped in the block `$escaper` (`escapeHtml` / `escapeHtmlAttr` / `escapeUrl`).

Note: may overlap with the open #78 "PHP Codesniffer pass" — happy to rebase/coordinate.